### PR TITLE
Properly link NS Extension Principal Class

### DIFF
--- a/src/withInfoPlist.ts
+++ b/src/withInfoPlist.ts
@@ -24,7 +24,7 @@ export const withInfoPlist: ConfigPlugin<{ folderName: string }> = (
       const extensionPlist: InfoPlist = {
         NSExtension: {
           NSExtensionPointIdentifier: "com.apple.Safari.web-extension",
-          NSExtensionPrincipalClass: "SafariWebExtensionHandler",
+          NSExtensionPrincipalClass: "$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler",
         },
       };
 


### PR DESCRIPTION
Fixes this fatal error when attempting to run `browser.runtime.sendNativeMessage`:

```
__extensionPrincipalClass != nil - /Library/Caches/com.apple.xbs/Sources/ExtensionFoundation_Sim/ExtensionFoundation/Source/NSExtension/NSExtensionSupport/EXConcreteExtensionContextVendor.m:109: Unable to find NSExtensionPrincipalClass (SafariWebExtensionHandler) in extension bundle! Please verify that the extension links the required frameworks and that the value for NSExtensionPrincipalClass is prefixed with '$(PRODUCT_MODULE_NAME).' if the class is implemented in Swift.
```